### PR TITLE
거래 내역 서버 - 경매 서버 조회 연동 로직 구현

### DIFF
--- a/src/main/java/org/indoles/receiptserviceserver/core/receipt/controller/ReceiptController.java
+++ b/src/main/java/org/indoles/receiptserviceserver/core/receipt/controller/ReceiptController.java
@@ -103,12 +103,15 @@ public class ReceiptController {
         return ResponseEntity.ok().build();
     }
 
-
-//
-//    // 거래 상세 조회 API
-//    @GetMapping("/transactions/{receiptId}")
-//    public ResponseEntity<ReceiptInfoResponse> getReceiptById(@PathVariable("receiptId") UUID receiptId) {
-//        ReceiptInfoResponse receiptInfo = receiptService.getReceiptById(receiptId);
-//        return ResponseEntity.ok(receiptInfo);
-//    }
+    /**
+     * 경매 환불 시 거래 내역 조회 API
+     */
+    @GetMapping("/find/{receiptId}")
+    public ResponseEntity<ReceiptInfoResponse> findReceiptById(
+            @Login SignInfoRequest signInfoRequest,
+            @PathVariable UUID receiptId
+    ){
+        ReceiptInfoResponse receiptInfoResponse = receiptService.getReceiptById(signInfoRequest,receiptId);
+        return ResponseEntity.ok(receiptInfoResponse);
+    }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 거래 내역 서버와 경매 서버간 환불시 필요한 조회를 연동하는 로직을 구현한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  거래 내역 서버, 경매 서버 조회 연동 로직 구현


---