### PR TITLE
거래 내역 서버 - 경매 서버 업데이트 연동 로직 작성

### DIFF
--- a/src/main/java/org/indoles/receiptserviceserver/core/receipt/controller/ReceiptController.java
+++ b/src/main/java/org/indoles/receiptserviceserver/core/receipt/controller/ReceiptController.java
@@ -114,4 +114,13 @@ public class ReceiptController {
         ReceiptInfoResponse receiptInfoResponse = receiptService.getReceiptById(signInfoRequest,receiptId);
         return ResponseEntity.ok(receiptInfoResponse);
     }
+
+    /**
+     * 경매 환불 시 업데이트 API
+     */
+    @PutMapping("/refund/{receiptId}")
+    public ResponseEntity<Void> processRefund(@PathVariable UUID receiptId) {
+        receiptService.processRefund(receiptId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/indoles/receiptserviceserver/core/receipt/service/ReceiptService.java
+++ b/src/main/java/org/indoles/receiptserviceserver/core/receipt/service/ReceiptService.java
@@ -167,4 +167,10 @@ public class ReceiptService {
         return receiptCoreRepository.findByIdForUpdate(receiptId).orElseThrow(
                 () -> new NotFoundException("환불할 입찰 내역을 찾을 수 없습니다. 내역 id=" + receiptId, ErrorCode.P002));
     }
+
+    public void processRefund(UUID receiptId) {
+        Receipt receipt = findRefundTargetReceiptForUpdate(receiptId);
+        receipt.markAsRefund();
+        receiptCoreRepository.save(receipt);
+    }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 거래 내역 서버와 경매 서버간 업데이트 연동 로직을 구현한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  거래 내역 서버와 경매 서버간 업데이트 연동 로직 구현


---